### PR TITLE
Lots of small changes to make tools/build-all.sh work under Mac OS X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ Fullproof is released under the terms of the Apache License, version 2.0, januar
 * Information can be found in the wiki: https://github.com/reyesr/fullproof/wiki
 * Bug reports and evolution requests can be reported at: https://github.com/reyesr/fullproof/issues
 
+##Building
+
+The `tools` directory contains `build-all.sh` that can be used to create a
+convenient `fullproof-all.js` file containing everything you might need to get
+going on a Fullproof project. Note that in a production system you may want to
+just include specific Javascript files, not everything (see the examples).
+
+To build `fullproof-all.js`:
+
+    $ cd tools
+    $ ./build-all.sh
+
+If you have the Google closure compiler (see
+https://developers.google.com/closure/compiler/) you might prefer to run
+
+    $ cd tools
+    $ CLOSURE_COMPILER_JAR=/path/to/your/compiler.jar ./build-all.sh
+
+All output from the build process will appear in the top-level `build`
+directory.  In particular, see `build/js/fullproof-all.js`.
+
 ##Contribute !
 
 You can help improve fullproof and fulltext research by creating new algorithms:

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-ROOT=`dirname "$0"`/..
-ROOT=`readlink -e "$ROOT"`
-BUILD="$ROOT"/build
+test -f common.sh || {
+    echo "The `basename $0` script must be invoked from the tools directory." >&2
+    exit 1
+}
+
+. common.sh
 
 rm -fr "$BUILD"
 mkdir -p "$BUILD"
@@ -10,17 +13,17 @@ mkdir -p "$BUILD"
 ./build-src.sh
 ./build-site.sh
 
-shopt -s globstar
-
 if [[ "$JSDOC" == "" ]] ; then
+    set +e
     JSDOC=`which jsdoc`
+    set -e
 fi
 
 if [[ "$JSDOC" != "" ]] ; then
 	echo "now building documentation"
 	DOC="$BUILD/site/jsdocs"
 	mkdir -p "$DOC"
-	"$JSDOC" -d="$DOC" "$ROOT"/**/*.js
+	"$JSDOC" -d="$DOC" "$ROOT"/*/*.js
 else
     echo '[WARNING] jsdoc is not available, skipping' >&2
 fi
@@ -29,13 +32,11 @@ RELEASENAME=fullproof-`date +%Y%m%d`
 RELEASEDIR="$BUILD"/"$RELEASENAME"
 mkdir -p  "$RELEASEDIR"
 cp -r "$BUILD"/js/ "$RELEASEDIR"/
-cp -r "$BUILD"/site/jsdocs "$RELEASEDIR"/
-cp -r "$BUILD"/site/jsdocs "$RELEASEDIR"/
+test -n "$JSDOCS" && cp -r "$BUILD"/site/jsdocs "$RELEASEDIR"/
 cp "$ROOT"/README.md "$RELEASEDIR"/
 cp "$ROOT"/LICENSE "$RELEASEDIR"/
 cp -r "$BUILD"/site/examples "$RELEASEDIR"
 
-ORGDIR=`pwd`
 cd "$BUILD"
 zip -r "$RELEASENAME".zip "$RELEASENAME"
 tar cvf "$RELEASENAME".tar "$RELEASENAME"

--- a/tools/build-site.sh
+++ b/tools/build-site.sh
@@ -60,7 +60,7 @@ process_example_dir () {
     done
 }
 
-test -d  "$BUILD"/site/examples || mkdir -p "$BUILD"/site/examples
+test -d "$BUILD"/site/examples || mkdir -p "$BUILD"/site/examples
 for example in colors mame animals
 do
     process_example_dir "$ROOT"/examples/$example "$BUILD"/site/examples/$example

--- a/tools/build-site.sh
+++ b/tools/build-site.sh
@@ -18,7 +18,6 @@ set +e
 which pandoc
 case $? in
     0)
-        set +e
         for file in "$SITEROOT"/*.md
         do
             TARGETNAME=`basename "$file"`

--- a/tools/build-src.sh
+++ b/tools/build-src.sh
@@ -9,11 +9,15 @@
 # url to make a call to the web service.
 #
 # To customize your distribution, just add a new distribution with your own files.
-#
-ROOT=`dirname "$0"`/..
-ROOT=`readlink -e "$ROOT"`
-BUILD="$ROOT"/build/js
 
+test -f common.sh || {
+    echo "The `basename $0` script must be invoked in the tools directory." >&2
+    exit 1
+}
+
+. common.sh
+
+BUILD="$BUILD"/js
 BASE="$ROOT/src/*.js  $ROOT/src/stores/*.js $ROOT/src/misc/*.js"
 UNICODE="$ROOT/src/unicode/categ_letters_numbers.js $ROOT/src/unicode/normalizer_lowercase_nomark.js $ROOT/src/unicode/unicode.js"
 ENGLISH=$ROOT/src/normalizers/english/*.js
@@ -46,7 +50,7 @@ build_version_online ()
 {
 	TARGET="$1"
 	shift
-	local TEMPFILE=`mktemp`
+	local TEMPFILE=`mktemp $MKTEMP_ARGS`
 	local JSOPT=
 	while (( "$#" )); do
 		JSOPT="$JSOPT --js $1"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,0 +1,35 @@
+# Set ROOT and BUILD vars for use by the various build scripts in this
+# directory.
+
+case "`uname`" in
+    Darwin)
+        LINK=`readlink ..`
+        case $? in
+            0)
+                ROOT="$LINK"
+            ;;
+            *)
+                ROOT=..
+            ;;
+        esac
+        set -e
+        MKTEMP_ARGS='-t fullproof-XXXXXX'
+        READLINK_F_FLAG=
+        ;;
+    *)
+        set -e
+        ROOT=`readlink -e ..`
+        MKTEMP_ARGS=
+        READLINK_F_FLAG=-f
+    ;;
+esac
+
+# Check $ROOT isn't empty (that would cause us to try removing / in build-
+# all.sh and maybe elsewhere).
+
+test -n "$ROOT" || {
+    echo "Failed to set ROOT to non-empty value." >&2
+    exit 2
+}
+
+BUILD="$ROOT"/build


### PR DESCRIPTION
I've commented out (for now) the awk invocation in `tools/build-site.sh` because `dev2build-html.awk` is not in this repo.

I removed the use of globstar which doesn't exist on Mac OS X and which didn't seem to be needed.

Lots of other little things to make this cleaner or safer, e.g., don't try to `rm -fr /` when `readlink` fails on a mac :-).

Fixes #4
