### PR TITLE
fix indexing tokens that are also properties on Object.prototype with memory_store

### DIFF
--- a/src/stores/memory_store.js
+++ b/src/stores/memory_store.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 var fullproof = fullproof || {};
 fullproof.store = fullproof.store||{};
 
@@ -25,13 +25,13 @@ fullproof.store = fullproof.store||{};
 		this.comparatorObject = null;
 		this.useScore= false;
 	}
-	
+
 	fullproof.store.MemoryStore = function() {
-		
+
 		if (!(this instanceof fullproof.store.MemoryStore)) {
 			return new fullproof.store.MemoryStore(comparatorObject);
-		}		
-		
+		}
+
 		this.indexes = {};
 		return this;
 	};
@@ -78,17 +78,17 @@ fullproof.store = fullproof.store||{};
 			}
 		});
 	};
-	
+
 	fullproof.store.MemoryStore.prototype.getIndex = function(name) {
 		return this.indexes[name];
 	};
 
-	
+
 	fullproof.store.MemoryStore.prototype.close = function(callback) {
 		this.indexes = {};
 		callback(this);
 	};
-	
+
 	MemoryStoreIndex.prototype.clear = function (callback) {
         this.data = {};
         if (callback) {
@@ -96,18 +96,18 @@ fullproof.store = fullproof.store||{};
         }
         return this;
     };
-	
+
 	/**
 	 * Inject data. Can be called as follows:
 	 * memstoreInstance.inject("someword", 31321321, callbackWhenDone);
 	 * memstoreInstance.inject("someword", new fullproof.ScoredElement(31321321, 1.0), callbackWhenDone);
-	 * 
+	 *
 	 * When score is not set, and store is configured to store a score, then it is saved as undefined.
 	 * When the score is set, and the store is configured not to store a score, it raises an exception
 	 */
 
 	MemoryStoreIndex.prototype.inject = function(key, value, callback) {
-		if (!this.data[key]) {
+		if (!this.data.hasOwnProperty(key)) {
 			this.data[key] = new fullproof.ResultSet(this.comparatorObject);
 		}
 		if (this.useScore === false && value instanceof fullproof.ScoredElement) {
@@ -119,7 +119,7 @@ fullproof.store = fullproof.store||{};
 		if (callback) {
 			callback(key,value);
 		}
-		
+
 		return this;
 	};
 
@@ -137,7 +137,7 @@ fullproof.store = fullproof.store||{};
 		return this;
 	};
 
-	
+
 	MemoryStoreIndex.prototype.lookup = function(word, callback) {
 		callback(this.data[word]?this.data[word].clone():new fullproof.ResultSet);
 		return this;

--- a/tests/common-testutils.js
+++ b/tests/common-testutils.js
@@ -11,7 +11,7 @@ fullproof = (function(NAMESPACE) {
 
 	NAMESPACE.ResultSet.prototype.testEquals = function(otherResultSet) {
 		otherResultSet = (otherResultSet instanceof fullproof.ResultSet)?otherResultSet.getDataUnsafe():otherResultSet;
-		
+
 		deepEqual(this.getDataUnsafe(),otherResultSet);
 	};
 
@@ -28,7 +28,7 @@ fullproof = (function(NAMESPACE) {
 		ok(true);
 		QUnit.start();
 	}
-	
+
 	NAMESPACE.tests.mkRandomString = function(size) {
 		var result = "";
 		for (var i=0;i<size; ++i) {
@@ -36,7 +36,7 @@ fullproof = (function(NAMESPACE) {
 		}
 		return result;
 	}
-	
+
 	NAMESPACE.tests.genericComparator = {
 			lower_than: function(a,b) {
 				var vala = a.value?a.value:a;
@@ -50,8 +50,22 @@ fullproof = (function(NAMESPACE) {
 			}
 		};
 
+
+	var problematicWords = [
+			// In Firefox, !!{}['watch'] is true.
+			'watch'
+	];
+
 	NAMESPACE.tests.makeResultSetOfScoredEntries = function(count, maxValue) {
 		var result = new fullproof.ResultSet(NAMESPACE.tests.genericComparator);
+		if (count > problematicWords.length) {
+			for (var i = 0; i < problematicWords.length; i++) {
+				var value = parseInt(Math.random() * maxValue);
+				result.insert(new NAMESPACE.ScoredEntry(
+						problematicWords[i], value, Math.random()*2));
+				count--;
+			}
+		}
 		for (var i=0; i<count; ++i) {
 			result.insert(NAMESPACE.ScoredEntry.prototype.mkRandom(maxValue));
 		}
@@ -68,13 +82,13 @@ fullproof = (function(NAMESPACE) {
 					intvalue: parseInt(Math.random()*1000)
 //					value: parseInt(Math.random()*100)
 			};
-			
+
 			result.insert(new NAMESPACE.ScoredEntry(NAMESPACE.tests.mkRandomString(10), obh, Math.random()*20));
 		}
 		return result;
 	};
 
-	
+
 	NAMESPACE.tests.testScoredElement = function(se1,se2) {
 		deepEqual(se1.value, se2.value);
 		equal(se1.score, se2.score);


### PR DESCRIPTION
A surprisingly tricky bug. When trying to index a set of documents that includes the word "watch" on Firefox with the memory store I was getting an error with `this.data[key].insert(value)` saying that .insert() wasn't defined.

As it turns out, the check to see if the key `"watch"` was present in `this.data` was giving a false positive. Switching to `Object#hasOwnProperty` seems to fix it.
